### PR TITLE
feat: TECH-02 — configuration de base Nuxt 3

### DIFF
--- a/app/composables/useApi.ts
+++ b/app/composables/useApi.ts
@@ -1,0 +1,18 @@
+// Wrapper autour de $fetch — centralise l'URL de base et l'injection du JWT Bearer.
+// Tous les appels API du projet passent par ici plutôt que d'appeler $fetch directement.
+export const useApi = <T>(
+  endpoint: string,
+  options?: Parameters<typeof $fetch>[1],
+) => {
+  const token = useCookie("token"); // JWT stocké en cookie (jamais localStorage)
+  const config = useRuntimeConfig(); // Lit NUXT_PUBLIC_API_URL selon l'environnement
+
+  return $fetch<T>(`${config.public.apiUrl}${endpoint}`, {
+    ...options,
+    headers: {
+      ...options?.headers,
+      // Injecte Authorization uniquement si le cookie token existe
+      ...(token.value ? { Authorization: `Bearer ${token.value}` } : {}),
+    },
+  });
+};

--- a/app/middleware/auth.ts
+++ b/app/middleware/auth.ts
@@ -1,0 +1,9 @@
+// Redirige vers /auth si aucun token JWT n'est présent dans le cookie
+
+export default defineNuxtRouteMiddleware(() => {
+    const token = useCookie('token');
+
+    if(!token.value){
+        return navigateTo ('/auth');
+    }
+});

--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -1,0 +1,41 @@
+import { defineStore } from "pinia";
+import type { User, AuthResponse } from '~/types';
+
+// Store d'authentification — persiste le JWT via cookie et expose l'user connecté à toute l'app
+export const useAuthStore = defineStore("auth", () => {
+  const token = useCookie<string | null>("token"); // Réactif et persiste entre les rechargements
+  const user = ref<User | null>(null);
+
+  const isAuthenticated = computed(() => !!token.value);
+
+  async function login(email: string, password: string) {
+    const data = await useApi<AuthResponse>("/auth/login", {
+      method: "POST",
+      body: { email, password },
+    });
+    token.value = data.access_token;
+    user.value = await useApi<User>('/users/me');  
+  }
+
+  async function register(pseudo: string, email: string, password: string){
+    const data = await useApi<AuthResponse>('/auth/register', {
+        method: 'POST',
+        body: {pseudo, email, password},
+    });
+    token.value = data.access_token;
+    user.value = await useApi<User>('/users/me');
+    }
+
+    function logout(){
+        token.value = null;
+        user.value= null;
+    }
+    return{
+        user,
+        token,
+        isAuthenticated,
+        login,
+        register,
+        logout
+    }
+});

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -1,0 +1,13 @@
+export interface User {
+    id: string;
+    pseudo: string;
+    email: string;
+    age: number|null;
+    familyId: string| null;
+    isFamilyOwner: boolean;
+    createdAt: string;
+}
+
+export interface AuthResponse{
+    access_token: string;
+}


### PR DESCRIPTION
  Configuration complète du frontend Nuxt 3.

  - nuxt.config.ts : mode SPA, modules, runtimeConfig
  - tailwind.config.js : couleurs Questy
  - composables/useApi.ts : wrapper $fetch avec injection JWT
  - middleware/auth.ts : protection des routes
  - stores/auth.ts : login, register, logout avec Pinia
  - types/index.ts : interfaces User et AuthResponse

  closes #41
  closes #42
  closes #43
  closes #44
  closes #38