### PR TITLE
[REFACTO-01] Remplacer styles inline et CSS   scoped par classes Tailwind

### DIFF
--- a/app/components/activity/Sheet.vue
+++ b/app/components/activity/Sheet.vue
@@ -83,8 +83,7 @@ function confirmCustom() {
     <div class="fixed inset-0 bg-black/75 z-40" @click="$emit('close')" />
 
     <!-- Sheet -->
-    <div class="fixed bottom-0 left-0 right-0 z-50 rounded-t-3xl max-h-[82vh] flex flex-col"
-         style="background: #211a6e; border-top: 1px solid rgba(127,119,221,0.25);">
+    <div class="fixed bottom-0 left-0 right-0 z-50 rounded-t-3xl max-h-[82vh] flex flex-col bg-questy-sheet border-t border-questy-violet/25">
 
       <!-- Handle -->
       <div class="flex justify-center pt-4 pb-2 flex-shrink-0">
@@ -93,8 +92,7 @@ function confirmCustom() {
 
       <!-- Recherche + filtres -->
       <div class="flex-shrink-0 px-4 pb-3 space-y-2">
-        <div class="flex items-center gap-2 rounded-2xl px-4 py-2.5 border border-questy-purple/40"
-             style="background: rgba(15,10,46,0.7);">
+        <div class="flex items-center gap-2 rounded-2xl px-4 py-2.5 border border-questy-purple/40 bg-questy-dark/70">
           <span class="text-questy-violet text-sm">🔍</span>
           <input
             v-model="search"
@@ -131,8 +129,7 @@ function confirmCustom() {
           <button
             v-for="activity in filtered"
             :key="activity.id"
-            class="w-full flex justify-between items-center py-3.5 border-b text-sm transition-colors"
-            style="border-color: rgba(83,74,183,0.15);"
+            class="w-full flex justify-between items-center py-3.5 border-b border-questy-purple/15 text-sm transition-colors"
             @click="selectActivity(activity)"
           >
             <span class="text-questy-light text-left">{{ activity.name }}</span>
@@ -147,7 +144,7 @@ function confirmCustom() {
       </div>
 
       <!-- Footer fixe : Autre activité -->
-      <div class="flex-shrink-0 px-4 py-3 border-t" style="border-color: rgba(83,74,183,0.2);">
+      <div class="flex-shrink-0 px-4 py-3 border-t border-questy-purple/20">
         <button
           v-if="!showCustom"
           class="w-full border border-dashed border-questy-purple/40 rounded-2xl py-3 text-sm text-questy-violet/80 transition-colors"
@@ -162,16 +159,14 @@ function confirmCustom() {
             v-model="localCustomName"
             type="text"
             placeholder="Nom de l'activité *"
-            class="w-full rounded-2xl px-4 py-2.5 text-sm text-questy-light placeholder-questy-violet/40 outline-none border border-questy-purple/30 focus:border-questy-purple"
-            style="background: rgba(15,10,46,0.7);"
+            class="w-full rounded-2xl px-4 py-2.5 text-sm text-questy-light placeholder-questy-violet/40 outline-none border border-questy-purple/30 focus:border-questy-purple bg-questy-dark/70"
             @input="customError = ''"
           />
           <input
             v-model="localCustomCategory"
             type="text"
             placeholder="Catégorie (optionnel)"
-            class="w-full rounded-2xl px-4 py-2.5 text-sm text-questy-light placeholder-questy-violet/40 outline-none border border-questy-purple/30 focus:border-questy-purple"
-            style="background: rgba(15,10,46,0.7);"
+            class="w-full rounded-2xl px-4 py-2.5 text-sm text-questy-light placeholder-questy-violet/40 outline-none border border-questy-purple/30 focus:border-questy-purple bg-questy-dark/70"
           />
           <div class="flex gap-2">
             <button

--- a/app/pages/auth.vue
+++ b/app/pages/auth.vue
@@ -79,21 +79,21 @@ async function submit() {
           type="text"
           placeholder="Pseudo"
           required
-          class="input"
+          class="w-full px-4 py-2 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-questy-purple text-questy-dark"
         />
         <input
           v-model="form.email"
           type="email"
           placeholder="Email"
           required
-          class="input"
+          class="w-full px-4 py-2 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-questy-purple text-questy-dark"
         />
         <input
           v-model="form.password"
           type="password"
           placeholder="Mot de passe"
           required
-          class="input"
+          class="w-full px-4 py-2 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-questy-purple text-questy-dark"
         />
         <input
           v-if="mode === 'register'"
@@ -101,7 +101,7 @@ async function submit() {
           type="password"
           placeholder="Confirmer le mot de passe"
           required
-          class="input"
+          class="w-full px-4 py-2 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-questy-purple text-questy-dark"
         />
 
         <!-- Message d'erreur -->
@@ -117,9 +117,3 @@ async function submit() {
     </div>
   </div>
 </template>
-
-<style scoped>
-.input {
-  @apply w-full px-4 py-2 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-questy-purple text-questy-dark;
-}
-</style>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,7 @@ export default {
         'questy-dark':   '#0F0A2E',
         'questy-light':  '#EEEDFE',
         'questy-violet': '#7F77DD',
+        'questy-sheet':  '#211a6e',
       },
     },
   },


### PR DESCRIPTION
  - Ajout du token `questy-sheet` (#211a6e) dans
  tailwind.config.js
  - Sheet.vue : 6 attributs style= remplacés par classes
  Tailwind (bg-questy-sheet, bg-questy-dark/70,
  border-questy-violet/25, border-questy-purple/15,
  border-questy-purple/20)
  - auth.vue : bloc <style scoped> supprimé, classes
  appliquées directement sur les inputs

  Closes #126