### PR TITLE
[REFACTO-02] Centraliser xpPercent et   updateProfile dans les stores

### DIFF
--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -10,14 +10,7 @@ const error = computed(() => avatarStore.error || partsStore.error);
 const avatar = computed(() => avatarStore.avatar);
 const maxStat = computed(() => avatarStore.maxStat);
 
-const xpPercent = computed(() => {
-  if (!avatar.value) return 0;
-  const { xp, xpNextLevel, level } = avatar.value;
-  const xpCurrentLevel = (((level - 1) * level) / 2) * 100;
-  const range = xpNextLevel - xpCurrentLevel;
-  if (range <= 0) return 100;
-  return Math.min(Math.round(((xp - xpCurrentLevel) / range) * 100), 100);
-});
+const xpPercent = computed(() => avatarStore.xpPercent);
 
 const authStore = useAuthStore();
 const pseudo = computed(() => authStore.user?.pseudo ?? "");

--- a/app/pages/profile.vue
+++ b/app/pages/profile.vue
@@ -17,14 +17,7 @@ const avatar = computed(() => avatarStore.avatar);
 const maxStat = computed(() => avatarStore.maxStat);
 const user = computed(() => authStore.user);
 
-const xpPercent = computed(() => {
-  if (!avatar.value) return 0;
-  const { xp, xpNextLevel, level } = avatar.value;
-  const xpCurrentLevel = (((level - 1) * level) / 2) * 100;
-  const range = xpNextLevel - xpCurrentLevel;
-  if (range <= 0) return 100;
-  return Math.min(Math.round(((xp - xpCurrentLevel) / range) * 100), 100);
-});
+const xpPercent = computed(() => avatarStore.xpPercent);
 
 const stats = [
   { key: "strength" as const, label: "Force", description: "Attaque physique" },
@@ -67,11 +60,7 @@ async function saveEdit() {
   editLoading.value = true;
   editError.value = null;
   try {
-    await useApi("/users/me", {
-      method: "PATCH",
-      body: { pseudo: editPseudo.value, age: editAge.value },
-    });
-    await authStore.fetchUser();
+    await authStore.updateProfile(editPseudo.value, editAge.value);
     editMode.value = false;
   } catch (e: unknown) {
     const err = e as { data?: { message?: string } };

--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -34,6 +34,11 @@ export const useAuthStore = defineStore("auth", () => {
         user.value = await useApi<User>('/users/me');
     }
 
+    async function updateProfile(pseudo: string, age: number | null) {
+        await useApi('/users/me', { method: 'PATCH', body: { pseudo, age } });
+        await fetchUser();
+    }
+
     function logout(){
         token.value = null;
         user.value= null;
@@ -46,5 +51,6 @@ export const useAuthStore = defineStore("auth", () => {
         register,
         logout,
         fetchUser,
+        updateProfile,
     }
 });

--- a/app/stores/avatar.ts
+++ b/app/stores/avatar.ts
@@ -6,8 +6,16 @@ export const useAvatarStore = defineStore("avatar", () => {
   const loading = ref(false);
   const error = ref<string | null>(null);
 
-  // Stat la plus haute parmi les 6 — sert de référence pour les barres de progression
+  const xpPercent = computed(() => {
+    if (!avatar.value) return 0;
+    const { xp, xpNextLevel, level } = avatar.value;
+    const xpCurrentLevel = (((level - 1) * level) / 2) * 100;
+    const range = xpNextLevel - xpCurrentLevel;
+    if (range <= 0) return 100;
+    return Math.min(Math.round(((xp - xpCurrentLevel) / range) * 100), 100);
+  });
 
+  // Stat la plus haute parmi les 6 — sert de référence pour les barres de progression
   const maxStat = computed(() => {
     if (!avatar.value) return 1;
     const { strength, agility, endurance, intelligence, spirit, vitality } =
@@ -34,6 +42,6 @@ export const useAvatarStore = defineStore("avatar", () => {
         loading.value = false
     }
   }
-  return { avatar, loading, error, maxStat, fetchAvatar
+  return { avatar, loading, error, maxStat, xpPercent, fetchAvatar
   }
 });


### PR DESCRIPTION
  - avatarStore : ajout du computed xpPercent (supprime la
  duplication entre dashboard et profil)
  - authStore : ajout de updateProfile() (supprime le useApi
  direct dans profile.vue)
  - dashboard.vue : xpPercent local remplacé par
  avatarStore.xpPercent
  - profile.vue : xpPercent local remplacé + saveEdit() passe
   par authStore.updateProfile()

  Closes #127