### PR TITLE
feat(dashboard): refonte layout — Auberge, portrait agrandi, stats 2×3, cœurs 2×6

### DIFF
--- a/app/components/parts/PartsDisplay.vue
+++ b/app/components/parts/PartsDisplay.vue
@@ -7,7 +7,7 @@ const hearts = computed(() =>
 </script>
 
 <template>
-  <div class="flex flex-wrap gap-0.5">
+  <div class="grid grid-cols-6 gap-0.5">
     <span v-for="(full, i) in hearts" :key="i" class="text-base leading-none">
       {{ full ? "❤️" : "🤍" }}
     </span>

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -41,19 +41,13 @@ onMounted(async () => {
 
       <!-- HAUT : Header + XP -->
       <div class="max-w-xl mx-auto w-full px-4 sm:px-8 pt-6 sm:pt-10 space-y-4">
-        <header class="flex items-start justify-between border-b border-questy-gold/20 pb-4">
-          <div>
-            <h1
-              class="text-3xl sm:text-4xl font-bold italic text-questy-gold"
-              style="font-family: 'Newsreader', serif"
-            >
-              Tableau de Bord
-            </h1>
-            <p class="text-xs sm:text-sm text-questy-light/50 uppercase tracking-widest mt-1">
-              Ta progression RPG
-            </p>
-          </div>
-          <PartsDisplay :stock="partsStore.stock" />
+        <header class="border-b border-questy-gold/20 pb-4">
+          <h1
+            class="text-2xl sm:text-3xl font-bold italic text-questy-gold text-center"
+            style="font-family: 'Newsreader', serif"
+          >
+            Auberge
+          </h1>
         </header>
 
         <!-- Classe + XP -->
@@ -74,27 +68,23 @@ onMounted(async () => {
             <span class="text-xs text-questy-gold">{{ xpPercent }}%</span>
           </div>
         </div>
+
+        <!-- Cœurs -->
+        <PartsDisplay :stock="partsStore.stock" />
       </div>
 
-      <!-- MILIEU : Portrait + Stats (occupe l'espace restant, centré) -->
-      <div class="flex-1 flex flex-col justify-center py-6 sm:py-8">
-        <div class="w-full sm:w-8/12 mx-auto px-4 sm:px-0">
-        <div class="grid grid-cols-3 gap-4 sm:gap-6 items-center">
-          <!-- Stats gauche -->
-          <div class="space-y-4 sm:space-y-5">
-            <AvatarStatBar large label="Force" :value="avatar.strength" :max-value="maxStat" :color="STAT_COLOR_MAP.strength" />
-            <AvatarStatBar large label="Agilité" :value="avatar.agility" :max-value="maxStat" :color="STAT_COLOR_MAP.agility" />
-            <AvatarStatBar large label="Endurance" :value="avatar.endurance" :max-value="maxStat" :color="STAT_COLOR_MAP.endurance" />
-          </div>
+      <!-- MILIEU : Portrait centré + Stats 2×3 -->
+      <div class="flex-1 flex flex-col items-center justify-center py-6 sm:py-8 px-4 sm:px-8 gap-6">
 
-          <!-- Portrait avatar encadré -->
-          <div class="relative bg-questy-sheet/90 border border-questy-gold/40 p-4 sm:p-5 flex flex-col items-center gap-2">
-            <span class="absolute top-[-3px] left-[-3px] w-5 h-5 border-t-2 border-l-2 border-questy-gold" />
-            <span class="absolute top-[-3px] right-[-3px] w-5 h-5 border-t-2 border-r-2 border-questy-gold" />
-            <span class="absolute bottom-[-3px] left-[-3px] w-5 h-5 border-b-2 border-l-2 border-questy-gold" />
-            <span class="absolute bottom-[-3px] right-[-3px] w-5 h-5 border-b-2 border-r-2 border-questy-gold" />
-            <div class="text-[9px] text-questy-gold/50 uppercase tracking-widest font-bold">Portrait</div>
-            <div v-if="avatar" class="scale-125 sm:scale-150 my-2 sm:my-4">
+        <!-- Portrait avatar encadré (grand) -->
+        <div class="relative bg-questy-sheet/90 border border-questy-gold/40 p-4 flex flex-col items-center gap-2">
+          <span class="absolute top-[-3px] left-[-3px] w-5 h-5 border-t-2 border-l-2 border-questy-gold" />
+          <span class="absolute top-[-3px] right-[-3px] w-5 h-5 border-t-2 border-r-2 border-questy-gold" />
+          <span class="absolute bottom-[-3px] left-[-3px] w-5 h-5 border-b-2 border-l-2 border-questy-gold" />
+          <span class="absolute bottom-[-3px] right-[-3px] w-5 h-5 border-b-2 border-r-2 border-questy-gold" />
+          <div class="text-[9px] text-questy-gold/50 uppercase tracking-widest font-bold">{{ authStore.user?.pseudo }}</div>
+          <div class="w-48 h-48 flex items-center justify-center">
+            <div class="scale-[3]">
               <AvatarCanvas
                 :silhouette="avatar.silhouette"
                 :skin-tone="avatar.skinTone"
@@ -105,15 +95,18 @@ onMounted(async () => {
               />
             </div>
           </div>
+        </div>
 
-          <!-- Stats droite -->
-          <div class="space-y-4 sm:space-y-5">
-            <AvatarStatBar large label="Intel." :value="avatar.intelligence" :max-value="maxStat" align="right" :color="STAT_COLOR_MAP.intelligence" />
-            <AvatarStatBar large label="Esprit" :value="avatar.spirit" :max-value="maxStat" align="right" :color="STAT_COLOR_MAP.spirit" />
-            <AvatarStatBar large label="Vitalité" :value="avatar.vitality" :max-value="maxStat" align="right" :color="STAT_COLOR_MAP.vitality" />
-          </div>
+        <!-- Stats 2 colonnes × 3 lignes -->
+        <div class="w-full max-w-xs sm:max-w-sm grid grid-cols-2 gap-3">
+          <AvatarStatBar large label="Force"     :value="avatar.strength"     :max-value="maxStat" :color="STAT_COLOR_MAP.strength" />
+          <AvatarStatBar large label="Intel."    :value="avatar.intelligence" :max-value="maxStat" :color="STAT_COLOR_MAP.intelligence" />
+          <AvatarStatBar large label="Agilité"   :value="avatar.agility"      :max-value="maxStat" :color="STAT_COLOR_MAP.agility" />
+          <AvatarStatBar large label="Esprit"    :value="avatar.spirit"       :max-value="maxStat" :color="STAT_COLOR_MAP.spirit" />
+          <AvatarStatBar large label="Endurance" :value="avatar.endurance"    :max-value="maxStat" :color="STAT_COLOR_MAP.endurance" />
+          <AvatarStatBar large label="Vitalité"  :value="avatar.vitality"     :max-value="maxStat" :color="STAT_COLOR_MAP.vitality" />
         </div>
-        </div>
+
       </div>
 
       <!-- BAS : CTAs -->


### PR DESCRIPTION
## Changements

  - Titre dashboard remplacé par "Auberge" (centré) — cohérent avec le background taverne
  - Label "Portrait" remplacé par le pseudo du héros dans le cadre avatar
  - Avatar affiché en grand (scale-[3]) centré sur la page
  - Stats réorganisées en grille 2×3 sous le portrait (au lieu de gauche/droite)
  - Cœurs affichés en 2 rangées de 6 (grid 6 colonnes)
  - Barre XP/classe placée avant les cœurs

  Closes #119
  Closes #120