### PR TITLE
fix(activities): écran bloqué après redirection

### DIFF
--- a/app/pages/activities.vue
+++ b/app/pages/activities.vue
@@ -46,7 +46,7 @@ function onSelect(activity: Activity | null, custom: boolean) {
 async function submit() {
   await activitiesStore.logActivity();
   if (activitiesStore.success) {
-    await Promise.all([avatarStore.fetchAvatar(), partsStore.fetchParts()]);
+    Promise.all([avatarStore.fetchAvatar(), partsStore.fetchParts()]).catch(() => {});
     timer = setTimeout(() => {
       activitiesStore.reset();
       navigateTo('/dashboard');


### PR DESCRIPTION
## Description
  Correction du bug BUG-05 : après une déclaration d'activité réussie, la page restait figée sur le message de succès et ne redirigait jamais vers le dashboard.

  ## Cause
  Le \`setTimeout\` de redirection attendait la fin du \`Promise.all([fetchAvatar, fetchParts])\`. Si un appel réseau était lent ou échouait, le timer ne démarrait pas.

  ## Fix
  Les refreshes sont lancés en fire-and-forget (\`.catch(() => {})\`). Le timer démarre immédiatement après le succès. Le dashboard recharge ses propres données via \`onMounted\`.

  closes #141