### PR TITLE
hotfix: responsive desktop, balance UI, skip défis

### DIFF
--- a/app/components/challenge/ChallengeCard.vue
+++ b/app/components/challenge/ChallengeCard.vue
@@ -13,6 +13,7 @@ const isAvailable = computed(
 
 const statusLabel = computed(() => {
   if (props.item.atCap)            return 'Plafond atteint';
+  if (props.item.skippedToday)     return 'Quitté aujourd\'hui';
   if (props.item.alreadyDoneToday) return 'Déjà relevé';
   if (!props.item.canAfford)       return 'Pas assez de ❤️';
   return `+${props.item.monthlyBonus}/15 ce mois`;
@@ -40,7 +41,7 @@ const statusLabel = computed(() => {
 
     <!-- Coût + statut -->
     <div class="flex flex-col items-center md:items-end gap-0.5 md:flex-shrink-0">
-      <span class="text-xs text-gray-400">❤️❤️❤️</span>
+      <span class="text-xs text-gray-400">❤️</span>
       <span class="text-xs" :class="isAvailable ? 'text-questy-gold' : 'text-gray-500'">
         {{ statusLabel }}
       </span>

--- a/app/components/challenge/ChallengeCard.vue
+++ b/app/components/challenge/ChallengeCard.vue
@@ -25,13 +25,14 @@ const statusLabel = computed(() => {
     :style="{ background: meta.bg, borderColor: meta.color }"
     class="border rounded-xl transition-opacity w-full
            p-4 flex flex-col items-center gap-2
-           md:h-24 md:px-8 md:py-0 md:flex-row md:items-center md:gap-6"
+           md:h-24 md:px-8 md:py-0 md:flex-row md:items-center md:gap-6
+           lg:h-16 lg:px-4"
     :class="isAvailable ? 'opacity-100 cursor-pointer hover:opacity-90' : 'opacity-40 cursor-not-allowed'"
     :disabled="!isAvailable"
     @click="isAvailable && emit('select', item)"
   >
     <!-- Icône stat -->
-    <img :src="meta.icon" :alt="meta.label" class="w-8 h-8 md:w-10 md:h-10 object-contain flex-shrink-0" />
+    <img :src="meta.icon" :alt="meta.label" class="w-8 h-8 md:w-10 md:h-10 lg:w-7 lg:h-7 object-contain flex-shrink-0" />
 
     <!-- Nom (mobile) / Nom + titre défi (desktop) -->
     <div class="flex flex-col items-center md:items-start md:flex-1 gap-0.5">

--- a/app/components/challenge/ChallengeIA.vue
+++ b/app/components/challenge/ChallengeIA.vue
@@ -75,7 +75,10 @@ async function sendAnswer(answer: string) {
       body: { sessionId: sessionId.value, message: answer },
     });
     messages.value.push({ role: 'assistant', content: res.message });
-    if (res.type === 'result') emit('result', res.success ?? false);
+    if (res.type === 'result') {
+      await new Promise(resolve => setTimeout(resolve, 2500));
+      emit('result', res.success ?? false);
+    }
   } finally {
     loading.value = false;
   }

--- a/app/components/challenge/ChallengeIA.vue
+++ b/app/components/challenge/ChallengeIA.vue
@@ -3,7 +3,7 @@ import type { TodayChallenge } from '~/types';
 import { useApi } from '~/composables/useApi';
 
 const props = defineProps<{ item: TodayChallenge; color: string }>();
-const emit  = defineEmits<{ result: [success: boolean]; abandon: [sessionId: string | null] }>();
+const emit  = defineEmits<{ result: [success: boolean]; abandon: [sessionId: string | null]; 'session-started': [sessionId: string] }>();
 
 const messages  = ref<{ role: string; content: string }[]>([]);
 const sessionId = ref<string | null>(null);
@@ -56,6 +56,7 @@ async function start() {
       body: { stat: props.item.challenge.stat },
     });
     sessionId.value = res.sessionId;
+    emit('session-started', res.sessionId);
     messages.value.push({ role: 'assistant', content: res.message });
     started.value = true;
   } finally {

--- a/app/components/parts/PartsDisplay.vue
+++ b/app/components/parts/PartsDisplay.vue
@@ -11,7 +11,7 @@ const hearts = computed(() =>
     <span
       v-for="(full, i) in hearts"
       :key="i"
-      class="text-base lg:text-2xl leading-none"
+      class="text-base lg:text-lg leading-none"
     >
       {{ full ? "❤️" : "🤍" }}
     </span>

--- a/app/pages/activities.vue
+++ b/app/pages/activities.vue
@@ -21,8 +21,10 @@ const canSubmitReading = computed(
 );
 
 const INTENSITY_TO_DIFFICULTY: Record<number, 'easy' | 'medium' | 'hard'> = {
-  1: 'easy', 2: 'medium', 3: 'hard',
+  1: 'easy', 1.15: 'medium', 1.30: 'hard',
 };
+
+const bookDifficulty = computed(() => INTENSITY_TO_DIFFICULTY[activitiesStore.intensity] ?? 'easy');
 
 // Quiz — état
 const showQuizModal    = ref(false);
@@ -49,9 +51,9 @@ const durations = [
 ];
 
 const intensities = [
-  { label: 'Légère',  value: 1,   img: '/images/icons/intensity-1.png' },
-  { label: 'Modérée', value: 1.5, img: '/images/icons/intensity-2.png' },
-  { label: 'Intense', value: 2,   img: '/images/icons/intensity-3.png' },
+  { label: 'Légère',  value: 1,    img: '/images/icons/intensity-1.png' },
+  { label: 'Modérée', value: 1.15, img: '/images/icons/intensity-2.png' },
+  { label: 'Intense', value: 1.30, img: '/images/icons/intensity-3.png' },
 ];
 
 
@@ -188,22 +190,22 @@ function closeResultAndGoHome() {
     style="font-family: 'Be Vietnam Pro', sans-serif; background-image: linear-gradient(rgba(0,0,0,0.50), rgba(0,0,0,0.50)), url('/images/bg-forest.jpg')"
   >
     <!-- Header -->
-    <header class="w-full px-4 sm:px-8 lg:px-16 pt-6 pb-4 border-b border-questy-gold/20">
+    <header class="w-full px-4 sm:px-8 lg:px-16 pt-6 pb-4 lg:pt-3 lg:pb-2 border-b border-questy-gold/20">
       <h1
-        class="text-3xl sm:text-4xl lg:text-5xl font-bold italic text-questy-gold flex items-end gap-2"
+        class="text-3xl sm:text-4xl lg:text-2xl font-bold italic text-questy-gold flex items-end gap-2"
         style="font-family: 'Newsreader', serif"
       >
-        <img src="/images/icons/icon-activities.png" alt="" class="w-12 h-12 sm:w-14 sm:h-14 lg:w-16 lg:h-16 object-contain" />
+        <img src="/images/icons/icon-activities.png" alt="" class="w-12 h-12 sm:w-14 sm:h-14 lg:w-9 lg:h-9 object-contain" />
         Mes Activités
       </h1>
-      <p class="text-xs sm:text-sm lg:text-base text-questy-light/50 uppercase tracking-widest mt-1">
+      <p class="text-xs sm:text-sm lg:text-xs text-questy-light/50 uppercase tracking-widest mt-1">
         Déclare tes efforts, gagne de l'XP
       </p>
     </header>
 
     <!-- Carte formulaire — s'étend sur toute la hauteur disponible -->
-    <div class="flex-1 flex items-center justify-center px-4 sm:px-8 lg:px-16 py-6 lg:py-10">
-      <div class="bg-questy-sheet/70 backdrop-blur-sm border border-questy-gold/30 rounded-xl p-5 sm:p-8 lg:p-10 flex flex-col max-w-2xl lg:max-w-3xl w-full">
+    <div class="flex-1 flex items-center justify-center px-4 sm:px-8 lg:px-16 py-6 lg:py-3">
+      <div class="bg-questy-sheet/70 backdrop-blur-sm border border-questy-gold/30 rounded-xl p-5 sm:p-8 lg:p-4 flex flex-col max-w-2xl lg:max-w-3xl w-full">
 
         <!-- Succès -->
         <div
@@ -223,7 +225,7 @@ function closeResultAndGoHome() {
         </div>
 
         <template v-else>
-          <div class="flex-1 flex flex-col space-y-6 lg:space-y-8">
+          <div class="flex-1 flex flex-col space-y-6 lg:space-y-3">
 
             <!-- Catégorie + Activité -->
             <ActivityCombobox @select="onSelect" />
@@ -233,19 +235,19 @@ function closeResultAndGoHome() {
               <div class="space-y-2">
                 <p class="text-xs lg:text-sm text-questy-gold/70 uppercase tracking-widest font-bold">Titre du livre</p>
                 <input v-model="bookTitle" type="text" placeholder="Ex : Le Seigneur des Anneaux"
-                  class="w-full bg-questy-dark/60 border border-questy-gold/40 px-4 py-3 lg:py-4 text-sm lg:text-base text-questy-light placeholder:text-questy-light/30 focus:outline-none focus:border-questy-gold" />
+                  class="w-full bg-questy-dark/60 border border-questy-gold/40 px-4 py-3 lg:py-2 text-sm lg:text-sm text-questy-light placeholder:text-questy-light/30 focus:outline-none focus:border-questy-gold" />
               </div>
               <div class="space-y-2">
                 <p class="text-xs lg:text-sm text-questy-gold/70 uppercase tracking-widest font-bold">Auteur</p>
                 <input v-model="bookAuthor" type="text" placeholder="Ex : J.R.R. Tolkien"
-                  class="w-full bg-questy-dark/60 border border-questy-gold/40 px-4 py-3 lg:py-4 text-sm lg:text-base text-questy-light placeholder:text-questy-light/30 focus:outline-none focus:border-questy-gold" />
+                  class="w-full bg-questy-dark/60 border border-questy-gold/40 px-4 py-3 lg:py-2 text-sm lg:text-sm text-questy-light placeholder:text-questy-light/30 focus:outline-none focus:border-questy-gold" />
               </div>
               <div class="space-y-2">
                 <p class="text-xs lg:text-sm text-questy-gold/70 uppercase tracking-widest font-bold">
                   Tome / Volume <span class="text-questy-light/30 normal-case font-normal">(optionnel)</span>
                 </p>
                 <input v-model="bookVolume" type="text" placeholder="Ex : Tome 2 — Les Deux Tours"
-                  class="w-full bg-questy-dark/60 border border-questy-gold/40 px-4 py-3 lg:py-4 text-sm lg:text-base text-questy-light placeholder:text-questy-light/30 focus:outline-none focus:border-questy-gold" />
+                  class="w-full bg-questy-dark/60 border border-questy-gold/40 px-4 py-3 lg:py-2 text-sm lg:text-sm text-questy-light placeholder:text-questy-light/30 focus:outline-none focus:border-questy-gold" />
               </div>
             </template>
 
@@ -255,7 +257,7 @@ function closeResultAndGoHome() {
               <div class="grid grid-cols-4 gap-2">
                 <button
                   v-for="d in durations" :key="d.value"
-                  class="py-2 lg:py-3 text-sm lg:text-base font-medium border transition-colors"
+                  class="py-2 lg:py-1 text-sm font-medium border transition-colors"
                   :class="activitiesStore.duration === d.value
                     ? 'bg-questy-gold/20 border-questy-gold text-questy-gold'
                     : 'bg-questy-dark/60 border-questy-gold/20 text-questy-light/60'"
@@ -271,7 +273,7 @@ function closeResultAndGoHome() {
               </p>
               <div class="grid grid-cols-3 gap-2">
                 <button v-for="i in intensities" :key="i.value" class="flex justify-center transition-all" @click="activitiesStore.intensity = i.value">
-                  <img :src="i.img" :alt="i.label" class="w-16 h-16 lg:w-20 lg:h-20 object-contain rounded-full transition-all" :class="activitiesStore.intensity === i.value ? 'opacity-100 scale-110' : 'opacity-40'" />
+                  <img :src="i.img" :alt="i.label" class="w-16 h-16 lg:w-11 lg:h-11 object-contain rounded-full transition-all" :class="activitiesStore.intensity === i.value ? 'opacity-100 scale-110' : 'opacity-40'" />
                 </button>
               </div>
             </div>
@@ -279,7 +281,7 @@ function closeResultAndGoHome() {
             <!-- Aperçu gains -->
             <div
               v-if="!isReadingActivity && activitiesStore.duration && activitiesStore.intensity"
-              class="relative bg-questy-dark/60 border border-questy-gold/40 px-4 py-3 lg:px-6 lg:py-4"
+              class="relative bg-questy-dark/60 border border-questy-gold/40 px-4 py-3 lg:px-3 lg:py-2"
             >
               <span class="absolute top-[-3px] left-[-3px] w-5 h-5 border-t-2 border-l-2 border-questy-gold" />
               <span class="absolute top-[-3px] right-[-3px] w-5 h-5 border-t-2 border-r-2 border-questy-gold" />
@@ -305,7 +307,7 @@ function closeResultAndGoHome() {
                 @click="submit"
               >
                 <div class="absolute inset-0 bg-gradient-to-b from-questy-gold to-[#d4af37]" />
-                <div class="relative px-6 py-4 lg:py-5 flex items-center justify-center gap-2 border-b-4 border-[#554300]/40">
+                <div class="relative px-6 py-4 lg:py-2 flex items-center justify-center gap-2 border-b-4 border-[#554300]/40">
                   <template v-if="activitiesStore.loading">
                     <span class="font-bold text-[#3c2f00] uppercase tracking-widest text-sm lg:text-base">Enregistrement...</span>
                   </template>

--- a/app/pages/activities.vue
+++ b/app/pages/activities.vue
@@ -13,8 +13,6 @@ const partsStore = usePartsStore();
 const bookTitle      = ref('');
 const bookAuthor     = ref('');
 const bookVolume     = ref('');
-const bookDifficulty = ref<'easy' | 'medium' | 'hard'>('easy');
-
 const isReadingActivity = computed(
   () => activitiesStore.selectedActivity?.category === 'Lecture',
 );
@@ -22,11 +20,9 @@ const canSubmitReading = computed(
   () => !isReadingActivity.value || (bookTitle.value.trim() !== '' && bookAuthor.value.trim() !== ''),
 );
 
-const difficultyOptions: { label: string; value: 'easy' | 'medium' | 'hard'; img: string }[] = [
-  { label: 'Facile',    value: 'easy',   img: '/images/icons/intensity-1.png' },
-  { label: 'Moyen',     value: 'medium', img: '/images/icons/intensity-2.png' },
-  { label: 'Difficile', value: 'hard',   img: '/images/icons/intensity-3.png' },
-];
+const INTENSITY_TO_DIFFICULTY: Record<number, 'easy' | 'medium' | 'hard'> = {
+  1: 'easy', 2: 'medium', 3: 'hard',
+};
 
 // Quiz — état
 const showQuizModal    = ref(false);
@@ -38,13 +34,6 @@ const quizLoading      = ref(false);
 const quizError        = ref('');
 const quizResult       = ref<{ score: number; xpGained: number; partsUnlocked: number } | null>(null);
 const chatContainer    = ref<HTMLElement | null>(null);
-
-// Synchronise l'intensité du store avec la difficulté du quiz pour les activités Lecture
-watchEffect(() => {
-  if (isReadingActivity.value) {
-    activitiesStore.intensity = ({ easy: 1, medium: 1.5, hard: 2 } as Record<string, number>)[bookDifficulty.value] ?? 1;
-  }
-});
 
 let timer: ReturnType<typeof setTimeout> | null = null;
 
@@ -89,7 +78,7 @@ async function submit() {
           title:        bookTitle.value,
           author:       bookAuthor.value,
           volume:       bookVolume.value || undefined,
-          difficulty:   bookDifficulty.value,
+          difficulty:   INTENSITY_TO_DIFFICULTY[activitiesStore.intensity] ?? 'easy',
           activityName: activitiesStore.selectedActivity!.name,
           activityId:   activitiesStore.selectedActivity!.id,
           duration:     activitiesStore.duration!,
@@ -278,19 +267,12 @@ function closeResultAndGoHome() {
             <!-- Intensité / Difficulté -->
             <div class="space-y-2">
               <p class="text-xs lg:text-sm text-questy-gold/70 uppercase tracking-widest font-bold">
-                {{ isReadingActivity ? 'Difficulté du quiz' : 'Intensité' }}
+                Intensité
               </p>
               <div class="grid grid-cols-3 gap-2">
-                <template v-if="isReadingActivity">
-                  <button v-for="d in difficultyOptions" :key="d.value" class="flex justify-center transition-all" @click="bookDifficulty = d.value">
-                    <img :src="d.img" :alt="d.label" class="w-16 h-16 lg:w-20 lg:h-20 object-contain rounded-full transition-all" :class="bookDifficulty === d.value ? 'opacity-100 scale-110' : 'opacity-40'" />
-                  </button>
-                </template>
-                <template v-else>
-                  <button v-for="i in intensities" :key="i.value" class="flex justify-center transition-all" @click="activitiesStore.intensity = i.value">
-                    <img :src="i.img" :alt="i.label" class="w-16 h-16 lg:w-20 lg:h-20 object-contain rounded-full transition-all" :class="activitiesStore.intensity === i.value ? 'opacity-100 scale-110' : 'opacity-40'" />
-                  </button>
-                </template>
+                <button v-for="i in intensities" :key="i.value" class="flex justify-center transition-all" @click="activitiesStore.intensity = i.value">
+                  <img :src="i.img" :alt="i.label" class="w-16 h-16 lg:w-20 lg:h-20 object-contain rounded-full transition-all" :class="activitiesStore.intensity === i.value ? 'opacity-100 scale-110' : 'opacity-40'" />
+                </button>
               </div>
             </div>
 

--- a/app/pages/challenges.vue
+++ b/app/pages/challenges.vue
@@ -64,8 +64,12 @@ async function handleSkip() {
 
 async function handlePhysicalDone() {
   if (!selected.value) return;
-  await useApi(`/challenges/${selected.value.challenge.id}/complete`, { method: 'POST' });
-  resultState.value = { show: true, success: true };
+  try {
+    await useApi(`/challenges/${selected.value.challenge.id}/complete`, { method: 'POST' });
+    resultState.value = { show: true, success: true };
+  } catch {
+    resultState.value = { show: true, success: false };
+  }
   await Promise.all([challengesStore.fetchToday(), partsStore.fetchParts()]);
 }
 
@@ -91,15 +95,15 @@ async function handleAbandon(sessionId?: string | null) {
 
 <template>
   <div
-    class="min-h-screen text-white pb-24 flex flex-col bg-cover bg-center bg-no-repeat"
+    class="min-h-screen text-white pb-24 lg:pb-4 flex flex-col bg-cover bg-center bg-no-repeat"
     style="background-image: linear-gradient(rgba(0,0,0,0.60), rgba(0,0,0,0.60)), url('/images/bg-challenge.png')"
   >
-    <div class="w-full max-w-lg md:max-w-3xl mx-auto px-4 md:px-8 py-6 flex-1 flex flex-col">
+    <div class="w-full max-w-lg md:max-w-3xl mx-auto px-4 md:px-8 py-6 lg:py-2 flex-1 flex flex-col">
 
-      <header class="mb-4 md:mb-8 flex items-start justify-between gap-4">
+      <header class="mb-4 md:mb-8 lg:mb-2 flex items-start justify-between gap-4">
         <div>
-          <h1 class="text-3xl sm:text-4xl lg:text-5xl font-bold italic text-questy-gold flex items-end gap-2" style="font-family: 'Newsreader', serif">
-            <img src="/images/icons/icon-challenge.png" alt="" class="w-12 h-12 sm:w-14 sm:h-14 lg:w-16 lg:h-16 object-contain" />
+          <h1 class="text-3xl sm:text-4xl lg:text-2xl font-bold italic text-questy-gold flex items-end gap-2" style="font-family: 'Newsreader', serif">
+            <img src="/images/icons/icon-challenge.png" alt="" class="w-12 h-12 sm:w-14 sm:h-14 lg:w-9 lg:h-9 object-contain" />
             Défis du jour
           </h1>
           <p class="text-xs md:text-sm text-questy-light/50 mt-1">❤️ par défi · +1 stat · max 15/mois</p>

--- a/app/pages/challenges.vue
+++ b/app/pages/challenges.vue
@@ -9,8 +9,10 @@ const challengesStore = useChallengesStore();
 const partsStore      = usePartsStore();
 const { todayChallenges, loading, error } = storeToRefs(challengesStore);
 
-const selected    = ref<TodayChallenge | null>(null);
-const resultState = ref<{ show: boolean; success: boolean } | null>(null);
+const selected        = ref<TodayChallenge | null>(null);
+const resultState     = ref<{ show: boolean; success: boolean } | null>(null);
+const showSkipModal   = ref(false);
+const currentSessionId = ref<string | null>(null);
 
 
 const selectedMeta = computed(() =>
@@ -34,8 +36,30 @@ async function openChallenge(item: TodayChallenge) {
 }
 
 function closeChallenge() {
-  selected.value    = null;
-  resultState.value = null;
+  selected.value         = null;
+  resultState.value      = null;
+  currentSessionId.value = null;
+}
+
+function requestClose() {
+  const type = selected.value?.challenge.type;
+  const needsConfirm = type === 'OBJECTIVE' || type === 'TIMED' || !!currentSessionId.value;
+  if (needsConfirm) { showSkipModal.value = true; } else { closeChallenge(); }
+}
+
+async function handleSkip() {
+  if (!selected.value) return;
+  showSkipModal.value = false;
+  try {
+    const type = selected.value.challenge.type;
+    if (type === 'OBJECTIVE' || type === 'TIMED') {
+      await useApi(`/challenges/${selected.value.challenge.id}/skip`, { method: 'POST' });
+    } else if (currentSessionId.value) {
+      await useApi('/challenges/ia/skip', { method: 'POST', body: { sessionId: currentSessionId.value } });
+    }
+  } catch { /* session introuvable ou déjà loggée */ }
+  await challengesStore.fetchToday();
+  closeChallenge();
 }
 
 async function handlePhysicalDone() {
@@ -78,7 +102,7 @@ async function handleAbandon(sessionId?: string | null) {
             <img src="/images/icons/icon-challenge.png" alt="" class="w-12 h-12 sm:w-14 sm:h-14 lg:w-16 lg:h-16 object-contain" />
             Défis du jour
           </h1>
-          <p class="text-xs md:text-sm text-questy-light/50 mt-1">❤️❤️❤️ par défi · +1 stat · max 15/mois</p>
+          <p class="text-xs md:text-sm text-questy-light/50 mt-1">❤️ par défi · +1 stat · max 15/mois</p>
         </div>
         <div class="flex flex-col items-end flex-shrink-0 mt-1 gap-0.5">
           <span class="text-lg leading-none">❤️ {{ partsStore.stock }}<span class="text-questy-light/40">/12</span></span>
@@ -104,7 +128,7 @@ async function handleAbandon(sessionId?: string | null) {
         <div class="w-full max-w-md md:max-w-2xl">
 
           <template v-if="!resultState?.show">
-            <UiBackButton label="Retour aux défis" @click="closeChallenge" />
+            <UiBackButton label="Retour aux défis" @click="requestClose" />
             <p class="text-xl md:text-3xl font-bold mb-4" style="font-family: 'Newsreader', serif" :style="{ color: selectedMeta?.color }">
               {{ selectedMeta?.label }}
             </p>
@@ -129,6 +153,7 @@ async function handleAbandon(sessionId?: string | null) {
               :color="selectedMeta!.color"
               @result="handleIAResult"
               @abandon="handleAbandon"
+              @session-started="currentSessionId = $event"
             />
           </template>
 
@@ -146,4 +171,21 @@ async function handleAbandon(sessionId?: string | null) {
 
     </div>
   </div>
+
+  <Teleport to="body">
+    <div v-if="showSkipModal" class="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4">
+      <div class="bg-gray-900 border border-gray-700 rounded-xl p-6 max-w-sm w-full text-center flex flex-col gap-4">
+        <p class="text-lg font-bold text-white">Quitter ce défi ?</p>
+        <p class="text-sm text-gray-400">Tu ne perdras pas de ❤️, mais ce défi sera <span class="text-questy-gold">bloqué pour aujourd'hui</span>.</p>
+        <div class="flex gap-3">
+          <button class="flex-1 py-2 rounded-lg bg-gray-700 text-white text-sm hover:bg-gray-600 transition" @click="showSkipModal = false">
+            Continuer le défi
+          </button>
+          <button class="flex-1 py-2 rounded-lg bg-red-900 text-red-200 text-sm hover:bg-red-800 transition" @click="handleSkip">
+            Quitter
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
 </template>

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -43,13 +43,13 @@ onMounted(async () => {
     <div v-else-if="avatar" class="flex-1 flex flex-col w-full">
 
       <!-- HAUT : Header + XP -->
-      <div class="w-full px-4 sm:px-8 lg:px-16 pt-6 sm:pt-8 space-y-4 max-w-5xl lg:max-w-none">
-        <header class="border-b border-questy-gold/20 pb-4">
+      <div class="w-full px-4 sm:px-8 lg:px-16 pt-6 sm:pt-8 lg:pt-3 space-y-4 lg:space-y-2 max-w-5xl lg:max-w-none">
+        <header class="border-b border-questy-gold/20 pb-4 lg:pb-2">
           <h1
-            class="text-3xl sm:text-4xl lg:text-5xl font-bold italic text-questy-gold flex items-end gap-2"
+            class="text-3xl sm:text-4xl lg:text-2xl font-bold italic text-questy-gold flex items-end gap-2"
             style="font-family: 'Newsreader', serif"
           >
-            <img src="/images/icons/icon-acceuil.png" alt="" class="w-12 h-12 sm:w-14 sm:h-14 lg:w-16 lg:h-16 object-contain" />
+            <img src="/images/icons/icon-acceuil.png" alt="" class="w-12 h-12 sm:w-14 sm:h-14 lg:w-9 lg:h-9 object-contain" />
             Auberge
           </h1>
         </header>
@@ -80,10 +80,10 @@ onMounted(async () => {
       </div>
 
       <!-- MILIEU : Layout 3 colonnes desktop / portrait + stats mobile -->
-      <div class="flex-1 flex flex-col lg:flex-row items-center justify-center py-6 sm:py-8 px-4 sm:px-8 lg:px-16 gap-6 lg:gap-10 xl:gap-16">
+      <div class="flex-1 flex flex-col lg:flex-row items-center justify-center py-6 sm:py-8 lg:py-3 px-4 sm:px-8 lg:px-16 gap-6 lg:gap-6 xl:gap-10">
 
         <!-- Stats gauche (Force, Agilité, Endurance) — desktop uniquement -->
-        <div class="hidden lg:flex flex-col justify-center gap-6 xl:gap-8 w-56 xl:w-72 shrink-0">
+        <div class="hidden lg:flex flex-col justify-center gap-6 lg:gap-3 xl:gap-8 w-56 lg:w-44 xl:w-72 shrink-0">
           <AvatarStatBar large align="right" label="Force"     :value="avatar.strength"  :max-value="100" :color="STAT_COLOR_MAP.strength" />
           <AvatarStatBar large align="right" label="Agilité"   :value="avatar.agility"   :max-value="100" :color="STAT_COLOR_MAP.agility" />
           <AvatarStatBar large align="right" label="Endurance" :value="avatar.endurance" :max-value="100" :color="STAT_COLOR_MAP.endurance" />
@@ -100,7 +100,7 @@ onMounted(async () => {
           <span class="absolute bottom-[-3px] left-[-3px] w-5 h-5 border-b-2 border-l-2 border-questy-gold" />
           <span class="absolute bottom-[-3px] right-[-3px] w-5 h-5 border-b-2 border-r-2 border-questy-gold" />
           <div class="text-[9px] lg:text-[11px] text-questy-gold/50 uppercase tracking-widest font-bold">{{ authStore.user?.pseudo }}</div>
-          <div class="w-48 h-48 lg:w-56 lg:h-56 xl:w-64 xl:h-64 flex items-center justify-center">
+          <div class="w-48 h-48 lg:w-40 lg:h-40 xl:w-48 xl:h-48 flex items-center justify-center">
             <div class="scale-[3]">
               <AvatarCanvas
                 :silhouette="avatar.silhouette"
@@ -115,7 +115,7 @@ onMounted(async () => {
         </div>
 
         <!-- Stats droite (Intelligence, Esprit, Vitalité) — desktop uniquement -->
-        <div class="hidden lg:flex flex-col justify-center gap-6 xl:gap-8 w-56 xl:w-72 shrink-0">
+        <div class="hidden lg:flex flex-col justify-center gap-6 lg:gap-3 xl:gap-8 w-56 lg:w-44 xl:w-72 shrink-0">
           <AvatarStatBar large label="Intelligence" :value="avatar.intelligence" :max-value="100" :color="STAT_COLOR_MAP.intelligence" />
           <AvatarStatBar large label="Esprit"       :value="avatar.spirit"       :max-value="100" :color="STAT_COLOR_MAP.spirit" />
           <AvatarStatBar large label="Vitalité"     :value="avatar.vitality"     :max-value="100" :color="STAT_COLOR_MAP.vitality" />
@@ -134,20 +134,20 @@ onMounted(async () => {
       </div>
 
       <!-- BAS : CTAs -->
-      <div class="w-full px-4 sm:px-8 lg:px-16 pb-6 sm:pb-10 grid grid-cols-2 gap-3 sm:gap-4 lg:gap-6">
+      <div class="w-full px-4 sm:px-8 lg:px-16 pb-6 sm:pb-10 lg:pb-3 grid grid-cols-2 gap-3 sm:gap-4 lg:gap-3">
         <button
           class="relative overflow-hidden active:translate-y-0.5 transition-transform"
           @click="navigateTo('/activities')"
         >
           <div class="absolute inset-0 bg-gradient-to-b from-questy-gold to-[#d4af37]" />
-          <div class="relative px-4 py-3 sm:py-4 lg:py-5 flex items-center justify-center gap-2 lg:gap-3 border-b-4 border-[#554300]/40">
+          <div class="relative px-4 py-3 sm:py-4 lg:py-2 flex items-center justify-center gap-2 lg:gap-3 border-b-4 border-[#554300]/40">
             <img src="/images/icons/icon-activities.png" alt="Activités" class="w-6 h-6 lg:w-8 lg:h-8 object-contain" />
             <span class="font-bold text-[#3c2f00] uppercase tracking-widest text-xs sm:text-sm lg:text-base">Activité</span>
           </div>
         </button>
         <NuxtLink
           to="/challenges"
-          class="bg-questy-sheet/90 border border-questy-gold/20 text-questy-gold font-bold text-xs sm:text-sm lg:text-base uppercase tracking-widest flex items-center justify-center gap-2 lg:gap-3 py-3 sm:py-4 lg:py-5"
+          class="bg-questy-sheet/90 border border-questy-gold/20 text-questy-gold font-bold text-xs sm:text-sm lg:text-sm uppercase tracking-widest flex items-center justify-center gap-2 lg:gap-3 py-3 sm:py-4 lg:py-2"
         >
           <img src="/images/icons/icon-challenge.png" alt="Défis" class="w-6 h-6 lg:w-8 lg:h-8 object-contain" />
           Défis

--- a/app/stores/activities.ts
+++ b/app/stores/activities.ts
@@ -20,8 +20,10 @@ export const useActivitiesStore = defineStore('activities', () => {
   });
 
   const partsPreview = computed(() => {
-    if (!duration.value) return 0;
-    return duration.value <= 30 ? 2 : duration.value <= 60 ? 4 : 6;
+    if (!duration.value || !intensity.value) return 0;
+    const INTENSITY_PARTS: Record<number, number> = { 1: 1, 1.15: 2, 1.30: 3 };
+    const partsByDuration = duration.value <= 30 ? 1 : duration.value <= 60 ? 2 : 3;
+    return partsByDuration + (INTENSITY_PARTS[intensity.value] ?? 1);
   });
 
   const canSubmit = computed(() => {

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -82,6 +82,7 @@ export interface ChallengeCatalog {
 export interface TodayChallenge {
   challenge: ChallengeCatalog;
   alreadyDoneToday: boolean;
+  skippedToday?: boolean;
   monthlyBonus: number;
   atCap: boolean;
   canAfford: boolean;


### PR DESCRIPTION
## Résumé

- Responsive desktop (`lg:`) sur dashboard, activités et défis — tout tient sur 1920×1080 sans scroll
- Valeurs intensité `1/1.15/1.30` alignées avec le backend
- `bookDifficulty` computed corrigé → boutons Vrai/Faux et A/B/C/D fonctionnels selon intensité
- `partsPreview` recalculé avec nouvelle formule durée + intensité
- Mécanique skip défi : modal confirmation, bouton retour sécurisé
- Délai 2.5s avant overlay résultat défi IA (temps de lire le verdict)
- `handlePhysicalDone` avec try/catch

## Plan de test

- [ ] Dashboard sur 1920×1080 → aucun scroll vertical
- [ ] Activités : intensité modérée → aperçu cœurs = 4 pour 1h
- [ ] Quiz lecture intensité légère → boutons Vrai/Faux
- [ ] Quitter un défi en cours → modal de confirmation
- [ ] Défi IA terminé → délai avant overlay résultat