### PR TITLE
fix: rechargement du rang mensuel après un combat

### DIFF
--- a/app/pages/tournament.vue
+++ b/app/pages/tournament.vue
@@ -37,7 +37,7 @@ async function startCombat() {
 
 async function handleResult() {
   combatData.value = null; // retour à la vue principale
-  await Promise.all([tournamentStore.fetchStatus(), tournamentStore.fetchRanking()]);
+  await Promise.all([tournamentStore.fetchStatus(), tournamentStore.fetchRanking(), rankStore.fetchRank()]);
 }
 </script>
 


### PR DESCRIPTION
## Résumé

Corrige l'absence de mise à jour du rang mensuel après la fin d'un combat de tournoi.

`rankStore.fetchRank()` n'était pas appelé dans `handleResult()`, forçant un rechargement manuel de la page pour voir les points mis à jour.

## Fichier modifié

- `app/pages/tournament.vue` — ajout de `rankStore.fetchRank()` dans le `Promise.all` de `handleResult()`

## Test

1. Faire un combat de tournoi
2. Vérifier que les points mensuels se mettent à jour sans rechargement de page