### PR TITLE
 feat: polish UI — orthographe, contrastes et classement tournoi

### DIFF
--- a/app/components/challenge/ChallengeCard.vue
+++ b/app/components/challenge/ChallengeCard.vue
@@ -32,12 +32,12 @@ const statusLabel = computed(() => {
     @click="isAvailable && emit('select', item)"
   >
     <!-- Icône stat -->
-    <img :src="meta.icon" :alt="meta.label" class="w-8 h-8 md:w-10 md:h-10 lg:w-7 lg:h-7 object-contain flex-shrink-0" />
+    <img :src="meta.icon" :alt="meta.label" class="w-10 h-10 md:w-10 md:h-10 lg:w-7 lg:h-7 object-contain flex-shrink-0" />
 
     <!-- Nom (mobile) / Nom + titre défi (desktop) -->
     <div class="flex flex-col items-center md:items-start md:flex-1 gap-0.5">
-      <span class="text-xs md:text-sm font-bold" :style="{ color: meta.color }">{{ meta.label }}</span>
-      <span class="hidden md:block text-xs text-questy-light/60 truncate max-w-xs">{{ item.challenge.title }}</span>
+      <span class="text-sm font-bold" :style="{ color: meta.color }">{{ meta.label }}</span>
+      <span class="text-xs text-questy-light/60 line-clamp-2 text-center md:text-left">{{ item.challenge.title }}</span>
     </div>
 
     <!-- Coût + statut -->

--- a/app/components/tournament/TournamentCombat.vue
+++ b/app/components/tournament/TournamentCombat.vue
@@ -289,8 +289,8 @@ const lastLog = computed(() => turnLogs.value[turnLogs.value.length - 1] ?? null
         {{ combatData.opponentPseudo }} utilise <strong class="text-white">{{ ACTION_LABELS[lastLog.opponentAction] ?? lastLog.opponentAction }}</strong>
         <span v-if="lastLog.opponentCrit" class="text-questy-gold"> (CRITIQUE !)</span>
       </p>
-      <p v-if="lastLog.playerDamageDealt > 0" class="text-green-400">Tu infliges {{ lastLog.playerDamageDealt }} dégâts.</p>
-      <p v-if="lastLog.opponentDamageDealt > 0" class="text-red-400">Tu subis {{ lastLog.opponentDamageDealt }} dégâts.</p>
+      <p v-if="lastLog.playerDamageDealt > 0" class="text-green-400">Tu infliges {{ lastLog.playerDamageDealt }} dégât{{ lastLog.playerDamageDealt > 1 ? 's' : '' }}.</p>
+      <p v-if="lastLog.opponentDamageDealt > 0" class="text-red-400">Tu subis {{ lastLog.opponentDamageDealt }} dégât{{ lastLog.opponentDamageDealt > 1 ? 's' : '' }}.</p>
     </div>
 
     <!-- ── Boutons d'action ── -->

--- a/app/components/tournament/TournamentRanking.vue
+++ b/app/components/tournament/TournamentRanking.vue
@@ -76,6 +76,7 @@ function goTo(page: number) {
         <img
           v-if="tierMap?.[entry.userId]"
           :src="RANK_ICON[tierMap[entry.userId]]"
+          alt=""
           class="w-5 h-5 object-contain shrink-0 mx-1"
         />
         <span class="flex-1 truncate" :class="entry.userId === authStore.user?.id ? 'text-questy-gold font-bold' : 'text-gray-200'">

--- a/app/components/tournament/TournamentRanking.vue
+++ b/app/components/tournament/TournamentRanking.vue
@@ -1,8 +1,18 @@
 <script setup lang="ts">
-import type { WeeklyRankEntry } from '~/types';
+import type { WeeklyRankEntry, RankTier } from '~/types';
 import { useAuthStore } from '~/stores/auth';
 
-const props  = defineProps<{ ranking: WeeklyRankEntry[] }>();
+const RANK_ICON: Record<RankTier, string> = {
+  BRONZE: '/images/rank-bronze.png',
+  SILVER: '/images/rank-silver.png',
+  GOLD:   '/images/rank-gold.png',
+  LEGEND: '/images/rank-legend.png',
+};
+
+const props  = defineProps<{
+  ranking: WeeklyRankEntry[];
+  tierMap?: Record<string, RankTier>;
+}>();
 const authStore = useAuthStore();
 
 const PAGE_SIZE = 10;
@@ -63,6 +73,11 @@ function goTo(page: number) {
         >
           {{ (currentPage - 1) * PAGE_SIZE + i + 1 }}
         </span>
+        <img
+          v-if="tierMap?.[entry.userId]"
+          :src="RANK_ICON[tierMap[entry.userId]]"
+          class="w-5 h-5 object-contain shrink-0 mx-1"
+        />
         <span class="flex-1 truncate" :class="entry.userId === authStore.user?.id ? 'text-questy-gold font-bold' : 'text-gray-200'">
           {{ entry.pseudo }}
           <span v-if="entry.userId === authStore.user?.id" class="text-[10px] text-questy-gold/60 ml-1">← toi</span>

--- a/app/components/ui/BottomNav.vue
+++ b/app/components/ui/BottomNav.vue
@@ -3,7 +3,7 @@ const route = useRoute();
 const authStore = useAuthStore();
 
 const allTabs = [
-  { label: 'Accueil',   img: '/images/icons/icon-acceuil.png',    path: '/dashboard' },
+  { label: 'Auberge',   img: '/images/icons/icon-acceuil.png',    path: '/dashboard' },
   { label: 'Activités', img: '/images/icons/icon-activities.png', path: '/activities' },
   { label: 'Défis',     img: '/images/icons/icon-challenge.png',  path: '/challenges' },
   { label: 'Tournoi',   img: '/images/icons/icon-tournament.png', path: '/tournament' },

--- a/app/components/ui/SideNav.vue
+++ b/app/components/ui/SideNav.vue
@@ -3,7 +3,7 @@ const route = useRoute();
 const authStore = useAuthStore();
 
 const allTabs = [
-  { label: 'Accueil',   img: '/images/icons/icon-acceuil.png',    path: '/dashboard' },
+  { label: 'Auberge',   img: '/images/icons/icon-acceuil.png',    path: '/dashboard' },
   { label: 'Activités', img: '/images/icons/icon-activities.png', path: '/activities' },
   { label: 'Défis',     img: '/images/icons/icon-challenge.png',  path: '/challenges' },
   { label: 'Tournoi',   img: '/images/icons/icon-tournament.png', path: '/tournament' },

--- a/app/pages/activities.vue
+++ b/app/pages/activities.vue
@@ -221,7 +221,7 @@ function closeResultAndGoHome() {
             +{{ activitiesStore.lastLog?.xpGained }} XP · +{{ activitiesStore.lastLog?.partsUnlocked }}
             <span class="material-symbols-outlined text-sm" style="font-variation-settings:'FILL' 1; color: #f2ca50">favorite</span>
           </p>
-          <p class="text-questy-light/40 text-xs mt-2">Retour au dashboard...</p>
+          <p class="text-questy-light/40 text-xs mt-2">Retour à l'Auberge...</p>
         </div>
 
         <template v-else>
@@ -272,8 +272,25 @@ function closeResultAndGoHome() {
                 Intensité
               </p>
               <div class="grid grid-cols-3 gap-2">
-                <button v-for="i in intensities" :key="i.value" class="flex justify-center transition-all" @click="activitiesStore.intensity = i.value">
-                  <img :src="i.img" :alt="i.label" class="w-16 h-16 lg:w-11 lg:h-11 object-contain rounded-full transition-all" :class="activitiesStore.intensity === i.value ? 'opacity-100 scale-110' : 'opacity-40'" />
+                <button
+                  v-for="i in intensities" :key="i.value"
+                  class="flex flex-col items-center gap-1 py-2 rounded-lg border transition-all"
+                  :class="activitiesStore.intensity === i.value
+                    ? 'bg-questy-gold/10 border-questy-gold/50'
+                    : 'border-transparent opacity-60'"
+                  @click="activitiesStore.intensity = i.value"
+                >
+                  <img
+                    :src="i.img" :alt="i.label"
+                    class="w-16 h-16 lg:w-11 lg:h-11 object-contain rounded-full transition-all"
+                    :class="activitiesStore.intensity === i.value ? 'scale-110' : ''"
+                  />
+                  <span
+                    class="text-xs font-medium"
+                    :class="activitiesStore.intensity === i.value ? 'text-questy-gold' : 'text-questy-light/60'"
+                  >
+                    {{ i.label }}
+                  </span>
                 </button>
               </div>
             </div>

--- a/app/pages/auth.vue
+++ b/app/pages/auth.vue
@@ -198,7 +198,7 @@ function switchMode(newMode: "login" | "register") {
             <div class="space-y-1.5">
               <label class="font-bold text-sm text-[#d4af37] flex items-center gap-2">
                 <span class="material-symbols-outlined text-[18px]">lock</span>
-                ✦ Sceau de Sécurité
+                ✦ Sceau de sécurité
               </label>
               <input
                 v-model="form.password"
@@ -229,7 +229,7 @@ function switchMode(newMode: "login" | "register") {
 
             <!-- Liens CGU / RGPD -->
             <p class="text-xs text-center text-[#8a7f6e]">
-              En créant un compte, vous acceptez nos
+              En utilisant Questy, vous acceptez nos
               <NuxtLink to="/cgu" target="_blank" class="text-questy-gold underline hover:text-[#e9c349] transition-colors">CGU</NuxtLink>
               et notre
               <NuxtLink to="/rgpd" target="_blank" class="text-questy-gold underline hover:text-[#e9c349] transition-colors">Politique de confidentialité</NuxtLink>.

--- a/app/pages/cgu.vue
+++ b/app/pages/cgu.vue
@@ -115,8 +115,8 @@
           <h2 class="text-lg font-semibold text-[#e9d5a0] mb-2">10. Contact</h2>
           <p>
             Pour toute question relative aux présentes CGU :
-            <a href="mailto:Loic.Leclercq@keiro.be" class="text-questy-gold underline hover:text-[#e9c349]">
-              Loic.Leclercq@keiro.be
+            <a href="mailto:lleclercq@outlook.com" class="text-questy-gold underline hover:text-[#e9c349]">
+              lleclercq@outlook.com
             </a>
           </p>
         </div>

--- a/app/pages/challenges.vue
+++ b/app/pages/challenges.vue
@@ -100,17 +100,14 @@ async function handleAbandon(sessionId?: string | null) {
   >
     <div class="w-full max-w-lg md:max-w-3xl mx-auto px-4 md:px-8 py-6 lg:py-2 flex-1 flex flex-col">
 
-      <header class="mb-4 md:mb-8 lg:mb-2 flex items-start justify-between gap-4">
-        <div>
-          <h1 class="text-3xl sm:text-4xl lg:text-2xl font-bold italic text-questy-gold flex items-end gap-2" style="font-family: 'Newsreader', serif">
-            <img src="/images/icons/icon-challenge.png" alt="" class="w-12 h-12 sm:w-14 sm:h-14 lg:w-9 lg:h-9 object-contain" />
-            Défis du jour
-          </h1>
-          <p class="text-xs md:text-sm text-questy-light/50 mt-1">❤️ par défi · +1 stat · max 15/mois</p>
-        </div>
-        <div class="flex flex-col items-end flex-shrink-0 mt-1 gap-0.5">
-          <span class="text-lg leading-none">❤️ {{ partsStore.stock }}<span class="text-questy-light/40">/12</span></span>
-          <span class="text-xs text-questy-light/50">cœurs disponibles</span>
+      <header class="mb-4 md:mb-8 lg:mb-2">
+        <h1 class="text-3xl sm:text-4xl lg:text-2xl font-bold italic text-questy-gold flex items-end gap-2" style="font-family: 'Newsreader', serif">
+          <img src="/images/icons/icon-challenge.png" alt="" class="w-12 h-12 sm:w-14 sm:h-14 lg:w-9 lg:h-9 object-contain" />
+          Défis du jour
+        </h1>
+        <div class="flex items-center justify-between mt-1">
+          <p class="text-sm text-questy-light/70">❤️ par défi · +1 stat · max 15/mois</p>
+          <span class="text-lg leading-none flex-shrink-0 ml-4">❤️ {{ partsStore.stock }}<span class="text-questy-light/40">/12</span></span>
         </div>
       </header>
 

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -145,13 +145,16 @@ onMounted(async () => {
             <span class="font-bold text-[#3c2f00] uppercase tracking-widest text-xs sm:text-sm lg:text-base">Activité</span>
           </div>
         </button>
-        <NuxtLink
-          to="/challenges"
-          class="bg-questy-sheet/90 border border-questy-gold/20 text-questy-gold font-bold text-xs sm:text-sm lg:text-sm uppercase tracking-widest flex items-center justify-center gap-2 lg:gap-3 py-3 sm:py-4 lg:py-2"
+        <button
+          class="relative overflow-hidden active:translate-y-0.5 transition-transform"
+          @click="navigateTo('/challenges')"
         >
-          <img src="/images/icons/icon-challenge.png" alt="Défis" class="w-6 h-6 lg:w-8 lg:h-8 object-contain" />
-          Défis
-        </NuxtLink>
+          <div class="absolute inset-0 bg-gradient-to-b from-[#7c3aed] to-[#6d28d9]" />
+          <div class="relative px-4 py-3 sm:py-4 lg:py-2 flex items-center justify-center gap-2 lg:gap-3 border-b-4 border-[#3b1285]/60">
+            <img src="/images/icons/icon-challenge.png" alt="Défis" class="w-6 h-6 lg:w-8 lg:h-8 object-contain" />
+            <span class="font-bold text-white uppercase tracking-widest text-xs sm:text-sm lg:text-base">Défis</span>
+          </div>
+        </button>
       </div>
     </div>
 

--- a/app/pages/tournament.vue
+++ b/app/pages/tournament.vue
@@ -25,6 +25,27 @@ const myMonthlyRank = computed(() => {
   return idx === -1 ? null : idx + 1;
 });
 
+const MONTHLY_PAGE_SIZE = 10;
+const monthlyCurrentPage = ref(1);
+const monthlyTotalPages  = computed(() => Math.ceil(monthlyLeaderboard.value.length / MONTHLY_PAGE_SIZE));
+const monthlyPage        = computed(() =>
+  monthlyLeaderboard.value.slice(
+    (monthlyCurrentPage.value - 1) * MONTHLY_PAGE_SIZE,
+    monthlyCurrentPage.value * MONTHLY_PAGE_SIZE,
+  )
+);
+const myMonthlyPage = computed(() =>
+  myMonthlyRank.value === null ? null : Math.ceil(myMonthlyRank.value / MONTHLY_PAGE_SIZE)
+);
+
+function goToMonthlyPage(p: number) {
+  monthlyCurrentPage.value = Math.min(Math.max(p, 1), monthlyTotalPages.value);
+}
+
+watch(monthlyLeaderboard, () => {
+  if (myMonthlyPage.value) monthlyCurrentPage.value = myMonthlyPage.value;
+}, { immediate: true });
+
 const RANK_ICON: Record<RankTier, string> = {
   BRONZE: '/images/rank-bronze.png',
   SILVER: '/images/rank-silver.png',
@@ -171,24 +192,49 @@ async function handleResult() {
               <div v-if="monthlyLeaderboard.length === 0" class="text-questy-light/50 text-sm text-center py-4">
                 Aucun combat ce mois.
               </div>
-              <div v-else class="space-y-1.5">
-                <div
-                  v-for="(entry, i) in monthlyLeaderboard"
-                  :key="entry.userId"
-                  class="flex items-center gap-2 rounded-lg px-3 py-2 text-sm"
-                  :class="entry.userId === authStore.user?.id
-                    ? 'bg-questy-gold/20 border border-questy-gold/50'
-                    : 'bg-gray-800/60'"
-                >
-                  <span class="font-bold w-6 shrink-0" :class="i < 3 ? 'text-questy-gold' : 'text-gray-500'">{{ i + 1 }}</span>
-                  <img :src="RANK_ICON[entry.tier]" class="w-5 h-5 object-contain shrink-0" />
-                  <span class="flex-1 truncate" :class="entry.userId === authStore.user?.id ? 'text-questy-gold font-bold' : 'text-gray-200'">
-                    {{ entry.pseudo }}
-                    <span v-if="entry.userId === authStore.user?.id" class="text-[10px] text-questy-gold/60 ml-1">← toi</span>
-                  </span>
-                  <span class="font-bold text-questy-gold shrink-0">{{ entry.totalPoints }} pts</span>
+              <template v-else>
+                <div class="space-y-1.5">
+                  <div
+                    v-for="(entry, i) in monthlyPage"
+                    :key="entry.userId"
+                    class="flex items-center gap-2 rounded-lg px-3 py-2 text-sm"
+                    :class="entry.userId === authStore.user?.id
+                      ? 'bg-questy-gold/20 border border-questy-gold/50'
+                      : 'bg-gray-800/60'"
+                  >
+                    <span class="font-bold w-6 shrink-0" :class="(monthlyCurrentPage - 1) * MONTHLY_PAGE_SIZE + i + 1 <= 3 ? 'text-questy-gold' : 'text-gray-500'">
+                      {{ (monthlyCurrentPage - 1) * MONTHLY_PAGE_SIZE + i + 1 }}
+                    </span>
+                    <img :src="RANK_ICON[entry.tier]" alt="" class="w-5 h-5 object-contain shrink-0" />
+                    <span class="flex-1 truncate" :class="entry.userId === authStore.user?.id ? 'text-questy-gold font-bold' : 'text-gray-200'">
+                      {{ entry.pseudo }}
+                      <span v-if="entry.userId === authStore.user?.id" class="text-[10px] text-questy-gold/60 ml-1">← toi</span>
+                    </span>
+                    <span class="font-bold text-questy-gold shrink-0">{{ entry.totalPoints }} pts</span>
+                  </div>
                 </div>
-              </div>
+
+                <div v-if="monthlyTotalPages > 1" class="flex items-center justify-between mt-3">
+                  <button
+                    :disabled="monthlyCurrentPage === 1"
+                    class="px-3 py-1 text-xs rounded-lg bg-gray-800/60 text-gray-400 disabled:opacity-30 hover:bg-gray-700/60 transition"
+                    @click="goToMonthlyPage(monthlyCurrentPage - 1)"
+                  >← Préc.</button>
+                  <div class="flex items-center gap-1">
+                    <button
+                      v-if="myMonthlyPage && myMonthlyPage !== monthlyCurrentPage"
+                      class="px-2 py-1 text-[10px] rounded-lg bg-questy-gold/20 text-questy-gold border border-questy-gold/40 hover:bg-questy-gold/30 transition"
+                      @click="goToMonthlyPage(myMonthlyPage)"
+                    >Me voir</button>
+                    <span class="text-xs text-gray-500">{{ monthlyCurrentPage }} / {{ monthlyTotalPages }}</span>
+                  </div>
+                  <button
+                    :disabled="monthlyCurrentPage === monthlyTotalPages"
+                    class="px-3 py-1 text-xs rounded-lg bg-gray-800/60 text-gray-400 disabled:opacity-30 hover:bg-gray-700/60 transition"
+                    @click="goToMonthlyPage(monthlyCurrentPage + 1)"
+                  >Suiv. →</button>
+                </div>
+              </template>
             </div>
           </div>
         </div>

--- a/app/pages/tournament.vue
+++ b/app/pages/tournament.vue
@@ -2,7 +2,7 @@
 import { useTournamentStore } from '~/stores/tournament';
 import { useAuthStore } from '~/stores/auth';
 import { useRankStore } from '~/stores/rank';
-import type { CombatStart } from '~/types';
+import type { CombatStart, MonthlyLeaderboardEntry, RankTier } from '~/types';
 
 definePageMeta({ middleware: 'auth' });
 
@@ -11,13 +11,34 @@ const authStore       = useAuthStore();
 const rankStore       = useRankStore();
 const { status, ranking, loading } = storeToRefs(tournamentStore);
 
-const combatData   = ref<CombatStart | null>(null);
-const startLoading = ref(false);
+const combatData          = ref<CombatStart | null>(null);
+const startLoading        = ref(false);
+const rankTab             = ref<'week' | 'month'>('week');
+const monthlyLeaderboard  = ref<MonthlyLeaderboardEntry[]>([]);
+
+const tierMap = computed<Record<string, RankTier>>(() =>
+  Object.fromEntries(monthlyLeaderboard.value.map(e => [e.userId, e.tier]))
+);
+
+const myMonthlyRank = computed(() => {
+  const idx = monthlyLeaderboard.value.findIndex(e => e.userId === authStore.user?.id);
+  return idx === -1 ? null : idx + 1;
+});
+
+const RANK_ICON: Record<RankTier, string> = {
+  BRONZE: '/images/rank-bronze.png',
+  SILVER: '/images/rank-silver.png',
+  GOLD:   '/images/rank-gold.png',
+  LEGEND: '/images/rank-legend.png',
+};
 
 onMounted(async () => {
   if (!authStore.user) await authStore.fetchUser();
   await tournamentStore.claimSlot();
   await Promise.all([tournamentStore.fetchStatus(), tournamentStore.fetchRanking(), rankStore.fetchRank()]);
+  try {
+    monthlyLeaderboard.value = await useApi<MonthlyLeaderboardEntry[]>('/rank/leaderboard');
+  } catch { /* endpoint indisponible */ }
   try {
     const current = await useApi<CombatStart | null>('/tournament/combat/current');
     if (current) combatData.value = current;
@@ -53,7 +74,7 @@ async function handleResult() {
           <img src="/images/icons/icon-tournament.png" alt="" class="w-12 h-12 sm:w-14 sm:h-14 lg:w-16 lg:h-16 object-contain" />
           Tournoi hebdomadaire
         </h1>
-        <p class="text-xs text-questy-light/50 mt-1">1 combat par jour · 7 max par semaine · Victoire +30pts · Défaite +10pts</p>
+        <p class="text-xs text-questy-light/50 mt-1">1 combat/jour · 7 max/semaine · Victoire +30pts · Défaite +10pts</p>
       </header>
 
       <div v-if="loading" class="flex-1 flex items-center justify-center">
@@ -75,9 +96,9 @@ async function handleResult() {
 
           <!-- Rang mensuel -->
           <div v-if="rankStore.rank" class="flex flex-col items-center gap-1">
-            <p class="text-[10px] text-gray-500 uppercase tracking-widest">Rang mensuel</p>
+            <p class="text-xs text-questy-light/60 uppercase tracking-widest">Rang mensuel</p>
             <RankBadge :tier="rankStore.rank.tier" :total-points="rankStore.rank.totalPoints" />
-            <p class="text-[11px] text-gray-500 text-center leading-snug">
+            <p class="text-sm text-questy-light/60 text-center leading-snug">
               Chaque combat rapporte des points · Victoire +30 · Défaite +10<br>
               Le rang est calculé en fin de mois selon ta position
             </p>
@@ -87,22 +108,26 @@ async function handleResult() {
           <div v-if="status" class="rounded-lg bg-gray-800/60 p-4 grid grid-cols-3 gap-2 text-center text-sm">
             <div>
               <p class="text-questy-gold font-bold text-lg">{{ status.wins }}</p>
-              <p class="text-gray-400 text-xs">Victoires</p>
+              <p class="text-questy-light/60 text-xs">Victoires</p>
             </div>
             <div>
               <p class="text-red-400 font-bold text-lg">{{ status.losses }}</p>
-              <p class="text-gray-400 text-xs">Défaites</p>
+              <p class="text-questy-light/60 text-xs">Défaites</p>
             </div>
             <div>
               <p class="text-questy-gold font-bold text-lg">{{ status.totalPoints }}</p>
-              <p class="text-gray-400 text-xs">Points</p>
+              <p class="text-questy-light/60 text-xs">Points</p>
             </div>
           </div>
 
-          <p v-if="status" class="text-xs text-center text-gray-500">
-            {{ status.claimedSlots - status.combatsThisWeek }} unité(s) disponible(s)
-            · {{ status.combatsThisWeek }}/{{ status.claimedSlots }} effectué(s) cette semaine
-          </p>
+          <div v-if="status" class="rounded-lg border border-questy-gold/30 bg-questy-gold/5 px-4 py-3 text-center">
+            <p class="text-questy-gold font-bold text-lg leading-none">
+              ⚔️ {{ status.claimedSlots - status.combatsThisWeek }} combat{{ (status.claimedSlots - status.combatsThisWeek) > 1 ? 's' : '' }} disponible{{ (status.claimedSlots - status.combatsThisWeek) > 1 ? 's' : '' }}
+            </p>
+            <p class="text-xs text-questy-light/60 mt-1">
+              {{ status.combatsThisWeek }} / {{ status.claimedSlots }} effectué{{ status.combatsThisWeek > 1 ? 's' : '' }} cette semaine
+            </p>
+          </div>
 
           <!-- Bouton combat -->
           <UiRpgButton
@@ -117,8 +142,55 @@ async function handleResult() {
               : '✅ Combat du jour effectué' }}
           </UiRpgButton>
 
-          <!-- Classement -->
-          <TournamentRanking :ranking="ranking" />
+          <!-- Toggle classement semaine / mois -->
+          <div class="mt-4">
+            <div class="flex rounded-lg overflow-hidden border border-questy-gold/20 mb-3">
+              <button
+                class="flex-1 py-2 text-xs font-bold uppercase tracking-wider transition-all"
+                :class="rankTab === 'week' ? 'bg-questy-gold text-[#3c2f00]' : 'text-questy-light/60 hover:text-questy-light'"
+                @click="rankTab = 'week'"
+              >Semaine</button>
+              <button
+                class="flex-1 py-2 text-xs font-bold uppercase tracking-wider transition-all"
+                :class="rankTab === 'month' ? 'bg-questy-gold text-[#3c2f00]' : 'text-questy-light/60 hover:text-questy-light'"
+                @click="rankTab = 'month'"
+              >Mois</button>
+            </div>
+
+            <!-- Classement hebdomadaire -->
+            <TournamentRanking v-if="rankTab === 'week'" :ranking="ranking" :tier-map="tierMap" />
+
+            <!-- Classement mensuel -->
+            <div v-else>
+              <div class="flex items-center justify-between mb-2">
+                <h3 class="text-questy-gold font-bold text-sm uppercase tracking-widest">Classement du mois</h3>
+                <span v-if="myMonthlyRank" class="text-xs text-questy-gold/60">
+                  Ta position : <strong class="text-questy-gold">#{{ myMonthlyRank }}</strong>
+                </span>
+              </div>
+              <div v-if="monthlyLeaderboard.length === 0" class="text-questy-light/50 text-sm text-center py-4">
+                Aucun combat ce mois.
+              </div>
+              <div v-else class="space-y-1.5">
+                <div
+                  v-for="(entry, i) in monthlyLeaderboard"
+                  :key="entry.userId"
+                  class="flex items-center gap-2 rounded-lg px-3 py-2 text-sm"
+                  :class="entry.userId === authStore.user?.id
+                    ? 'bg-questy-gold/20 border border-questy-gold/50'
+                    : 'bg-gray-800/60'"
+                >
+                  <span class="font-bold w-6 shrink-0" :class="i < 3 ? 'text-questy-gold' : 'text-gray-500'">{{ i + 1 }}</span>
+                  <img :src="RANK_ICON[entry.tier]" class="w-5 h-5 object-contain shrink-0" />
+                  <span class="flex-1 truncate" :class="entry.userId === authStore.user?.id ? 'text-questy-gold font-bold' : 'text-gray-200'">
+                    {{ entry.pseudo }}
+                    <span v-if="entry.userId === authStore.user?.id" class="text-[10px] text-questy-gold/60 ml-1">← toi</span>
+                  </span>
+                  <span class="font-bold text-questy-gold shrink-0">{{ entry.totalPoints }} pts</span>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
 
       </template>

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -155,6 +155,13 @@ export interface TournamentStatus {
 
 export type RankTier = 'BRONZE' | 'SILVER' | 'GOLD' | 'LEGEND';
 
+export interface MonthlyLeaderboardEntry {
+  userId: string;
+  pseudo: string;
+  totalPoints: number;
+  tier: RankTier;
+}
+
 export interface MonthlyRankResponse {
   tier: RankTier;
   totalPoints: number;


### PR DESCRIPTION
Description :
- Corrections orthographiques et de contraste sur toutes les pages (nav, activités, défis, tournoi, CGU)
- Boutons Activité/Défis du dashboard harmonisés (même gabarit, couleurs thématiques)
- Intensités activité : labels visibles + feedback visuel sélection
- Toggle Semaine/Mois dans le classement tournoi avec pagination et centrage automatique sur le joueur
- Icône de rang mensuel affichée pour chaque joueur dans les deux classements
- Nouveau type MonthlyLeaderboardEntry dans types/index.ts

Fichiers modifiés : tournament.vue, TournamentRanking.vue, dashboard.vue, challenges.vue, activities.vue, auth.vue, cgu.vue, ChallengeCard.vue, TournamentCombat.vue, BottomNav.vue, SideNav.vue, types/index.ts