### PR TITLE
fix: conformité W3C — lang et title manquants

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -11,6 +11,8 @@ export default defineNuxtConfig({
 
   app: {
     head: {
+      htmlAttrs: { lang: 'fr' },
+      title: 'Questy',
       link: [
         {
           rel: 'preconnect',


### PR DESCRIPTION
Description :
- Ajout de lang="fr" sur la balise <html> (accessibilité + W3C)
- Ajout de <title>Questy</title> dans le <head> (obligatoire HTML5)
- Correction globale : s'applique à toutes les pages via nuxt.config.ts

Fichier modifié : nuxt.config.ts